### PR TITLE
Add `do`-block format for `mkpidlock()`

### DIFF
--- a/src/Pidfile.jl
+++ b/src/Pidfile.jl
@@ -19,8 +19,8 @@ using Base.Sys: iswindows
     mkpidlock([f::Function], at::String, [pid::Cint, proc::Process]; kwopts...)
 
 Create a pidfile lock for the path "at" for the current process
-or the process identified by pid or proc.  Can take a function to execute once locked,
-for usage in `do` blocks, after which the lock will be automatically closed..
+or the process identified by pid or proc. Can take a function to execute once locked,
+for usage in `do` blocks, after which the lock will be automatically closed.
 
 Optional keyword arguments:
  - mode: file access mode (modified by the process umask). Defaults to world-readable.
@@ -60,7 +60,7 @@ mkpidlock(f::Function, at::String; kwopts...) = mkpidlock(f, at, getpid(); kwopt
 function mkpidlock(f::Function, at::String, pid::Cint; kwopts...)
     lock = mkpidlock(at, pid; kwopts...)
     try
-        f()
+        return f()
     finally
         close(lock)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -221,6 +221,23 @@ end
     if iswindows()
         rm("xpidfile")
     end
+
+    # Just for coverage's sake, run a test with do-block syntax
+    lock_times = Float64[]
+    t_loop = @async begin
+        for idx in 1:100
+            t = @elapsed mkpidlock("do_block_pidfile") do
+            end
+            sleep(0.01)
+            push!(lock_times, t)
+        end
+    end
+    mkpidlock("do_block_pidfile") do
+        sleep(3)
+    end
+    wait(t_loop)
+    @test maximum(lock_times) > 2
+    @test minimum(lock_times) < 1
 end
 
 end; end # cd(tempdir)


### PR DESCRIPTION
This makes it easier to write multiprocessing critical sections without needing to bother with exceptional control flow all the time.  :)