### PR TITLE
always rename a file before we delete it on Windows

### DIFF
--- a/src/Pidfile.jl
+++ b/src/Pidfile.jl
@@ -67,7 +67,7 @@ mutable struct LockMonitor
             lock = new(at, fd, update)
             finalizer(close, lock)
         catch ex
-            rm(at)
+            tryrmopenfile(at)
             close(fd)
             rethrow(ex)
         end
@@ -296,7 +296,7 @@ function tryrmopenfile(path::String)
         true
     catch ex
         isa(ex, IOError) || rethrow(ex)
-        false
+        ex
     end
 end
 
@@ -322,13 +322,7 @@ function Base.close(lock::LockMonitor)
         end
     if pathstat !== nothing && samefile(stat(lock.fd), pathstat)
         # try not to delete someone else's lock
-        try
-            rm(path)
-            removed = true
-        catch ex
-            ex isa IOError || rethrow()
-            removed = ex
-        end
+        removed = tryrmopenfile(path)
     end
     close(lock.fd)
     havelock = removed === true


### PR DESCRIPTION
Convert several occurrences of `rm` to `tryrmopenfile`.

Refs: https://github.com/JuliaLang/julia/pull/44984