### PR TITLE
Change v1.7 to v1.x for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,10 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.6'
-          - '1.7'
-          - 'nightly'
+          - '1.0' # old LTS (not yet broken)
+          - '1.6' # current LTS
+          - '1'   # current release
+          - 'nightly' # developement preview
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Same versions (for now), just specified differently in preparation for v1.8 Julia release