### PR TITLE
Remove `__precompile__()` from Pidfile.jl

### DIFF
--- a/src/Pidfile.jl
+++ b/src/Pidfile.jl
@@ -1,4 +1,3 @@
-__precompile__()
 module Pidfile
 
 


### PR DESCRIPTION
This is not necessary anymore since Julia 0.7